### PR TITLE
fix: PhotoPicker를 이용해 가져온 이미지에 대한 uri 권한 요청

### DIFF
--- a/app/src/main/java/com/example/nbc_sns/ui/profile/ProfileActivity.kt
+++ b/app/src/main/java/com/example/nbc_sns/ui/profile/ProfileActivity.kt
@@ -30,6 +30,10 @@ class ProfileActivity : AppCompatActivity(), PostClickListener {
     private val pickMedia =
         registerForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
             if (uri != null) {
+                // 앱이 지속되는 동안 uri를 통한 이미지 접근 권한을 부여 받음
+                // 앱이 종료된 후 다시 시작되면 해당 uri에 대한 접근 권한이 완전히 사라지므로, 사용자 프로필 변경 작업을 앱이 재시작하더라도 유지되게 refactoring할 때
+                // uri를 이용해 불러온 이미지를 앱에 할당된 저장 공간에 저장한 후, 해당 uri로 변환해야 함
+                contentResolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 updateUserProfileImage(uri)
             }
         }


### PR DESCRIPTION
## 원인
Photo picker를 이용해서 가져온 이미지에 대한 권한은 앱이 지속되는 동안 유지될 것으로 생각했으나, photo picker를 실행한 activity가 back stack에서 제거될 경우, uri를 통한 이미지 권한이 사라지는 것 같습니다.

그래서 앱이 멈추기 전까지 권한을 요청하는 코드를 추가했습니다.

```kotlin
val flag = Intent.FLAG_GRANT_READ_URI_PERMISSION
context.contentResolver.takePersistableUriPermission(uri, flag)
```

## 참고 자료
https://limheejin.tistory.com/184
https://developer.android.com/training/data-storage/shared/photopicker#persist-media-file-access